### PR TITLE
cannot connect to MongooseIM

### DIFF
--- a/lib/hedwig/conn.ex
+++ b/lib/hedwig/conn.ex
@@ -52,7 +52,6 @@ defmodule Hedwig.Conn do
     |> start_stream
     |> negotiate_features
     |> start_tls
-    |> negotiate_features
     |> authenticate
     |> bind
     |> session
@@ -84,7 +83,10 @@ defmodule Hedwig.Conn do
       true ->
         mod.send(conn, Stanza.start_tls)
         recv(conn, :wait_for_proceed)
-        mod.upgrade_to_tls(conn)
+
+        conn
+        |> mod.upgrade_to_tls()
+        |> negotiate_features()
       false ->
         conn
     end


### PR DESCRIPTION
hi! I'm trying to use Hedwig client but I'm finding some problems trying to connecte to MongooseIM XMPP server. I'm getting this:

```
4:31:25.813 [info]  Waiting for socket

14:31:25.822 [info]  Outgoing stanza: {:xmlstreamstart, "stream:stream", [{"to", "localhost"}, {"version", "1.0"}, {"xml:lang", "en"}, {"xmlns", "jabber:client"}, {"xmlns:stream", "http://etherx.jabber.org/streams"}]}

14:31:25.824 [debug] Incoming stanza: "<?xml version='1.0'?><stream:stream xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams' id='3300415738' from='localhost' version='1.0' xml:lang='en'><stream:features><mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'><mechanism>PLAIN</mechanism><mechanism>DIGEST-MD5</mechanism><mechanism>SCRAM-SHA-1</mechanism></mechanisms><register xmlns='http://jabber.org/features/iq-register'/><sm xmlns='urn:xmpp:sm:3'/></stream:features>"

14:31:26.830 [error] Error in process <0.109.0> with exit value: {{nocatch,{timeout,wait_for_features}},[{'Elixir.Hedwig.Conn',recv,2,[{file,"lib/hedwig/conn.ex"},{line,150}]},{'Elixir.Hedwig.Conn',negotiate_features,1,[{file,"lib/hedwig/conn.ex"},{line,77}]},{'Elixir.Hedwig.Conn',start,1,[{file...
```

The connection block is just:
```
defmodule XmppTests.Server do
	use GenServer

	require Logger

	def start_link(_opts) do
		client = %{
			jid: "yellow@localhost",
			password: "thepw",
			nickname: "yellow",
			rooms: [
				"yellow@localhost"
			],
			config: %{
				require_tls?: false,
				use_compression?: false,
				use_stream_management?: true,
				transport: :tcp
			},
			handlers: [{XmppTests.Handlers.Dummy, %{}}]
		}
		{:ok, _hedwig_pid} = Hedwig.Client.start_link(client)

		GenServer.start_link(__MODULE__, nil)
	end

end
```