### PR TITLE
Make it explicit that reply only handles messages

### DIFF
--- a/lib/hedwig/handler.ex
+++ b/lib/hedwig/handler.ex
@@ -42,11 +42,10 @@ defmodule Hedwig.Handler do
   end
 
   @doc """
-  Send a reply via the client pid.
+  Send a message reply via the client pid.
   """
-  def reply(msg, body) do
-    client = msg.client
-    msg = Stanza.message(JID.bare(msg.from), msg.type, body)
+  def reply(%Message{client: client, from: from, type: type}, body) do
+    msg = Stanza.message(JID.bare(from), type, body)
     Client.reply(client, msg)
   end
 


### PR DESCRIPTION
Before anything passed to the reply function would be wrapped as a
message, which might not be what the caller intended. With this change it will be impossible to pass anything but a %Message{} structure.