### PR TITLE
Add ability to register a user

### DIFF
--- a/lib/hedwig/stanza.ex
+++ b/lib/hedwig/stanza.ex
@@ -136,6 +136,21 @@ defmodule Hedwig.Stanza do
     iq("get", xmlel(name: "query", attrs: [{"xmlns", ns_roster}]))
   end
 
+  def get_inband_register do
+    iq("get", xmlel(name: "query", attrs: [{"xmlns", ns_inband_register}]))
+  end
+
+  def set_inband_register(username, password) do
+    iq("set", xmlel(
+      name: "query",
+      attrs: [{"xmlns", ns_inband_register}],
+      children: [
+        xmlel(name: "username", children: :exml.escape_cdata(username)),
+        xmlel(name: "password", children: :exml.escape_cdata(password))
+      ]
+    ))
+  end
+
   def get_vcard(to) do
     iq(to, "get", xmlel(name: "vCard", attrs: [{"xmlns", ns_vcard}]))
   end

--- a/test/hedwig/stanza_test.exs
+++ b/test/hedwig/stanza_test.exs
@@ -25,6 +25,16 @@ defmodule Hedwig.StanzaTest do
       "<starttls xmlns='#{ns_tls}'/>"
   end
 
+  test "get_inband_register" do
+    assert Stanza.get_inband_register |> Stanza.to_xml =~
+      ~r"<iq id='(.*)' type='get'><query xmlns='jabber:iq:register'/></iq>"
+  end
+
+  test "set_inband_register" do
+    assert Stanza.set_inband_register("username", "password") |> Stanza.to_xml =~
+      ~r"<iq id='(.*)' type='set'><query xmlns='jabber:iq:register'><username>username</username><password>password</password></query></iq>"
+  end
+
   test "compress" do
     assert Stanza.compress("zlib") |> Stanza.to_xml ==
       "<compress xmlns='#{ns_compress}'><method>zlib</method></compress>"


### PR DESCRIPTION
NOTE: This is hardcoded right now to the username/password style, which is not
agnostic enough to support all xmpp use cases.  However, it supports the
default for ejabberd and mongooseim, which is at least a decent start.  Unsure
if it should be merged or if we should support something more generic here
instead.